### PR TITLE
Handle nonexistent users in private timeline page

### DIFF
--- a/src/Chirp.Core/Interfaces/ICheepService.cs
+++ b/src/Chirp.Core/Interfaces/ICheepService.cs
@@ -14,4 +14,5 @@ public interface ICheepService
     Task<List<CheepDTO>> GetUserTimelineCheeps(string authorName, int pageNumber, int pageSize);
     Task<bool> DeleteCheep(int cheepId);
     Task<bool> DeleteAuthor(string authorName);
+    Task<bool> AuthorByNameExists(string authorName);
 }

--- a/src/Chirp.Core/Interfaces/IRepository.cs
+++ b/src/Chirp.Core/Interfaces/IRepository.cs
@@ -19,4 +19,5 @@ public interface IRepository
     Task<List<string>> GetAllFollowees(string authorName);
     Task<bool> DeleteCheep(int cheepId);
     Task<bool> DeleteAuthor(string authorName);
+    Task<bool> AuthorByNameExists(string authorName);
 }

--- a/src/Chirp.Infrastructure/Chirp.Repositories/Repository.cs
+++ b/src/Chirp.Infrastructure/Chirp.Repositories/Repository.cs
@@ -195,4 +195,13 @@ public class Repository : IRepository
         await _context.SaveChangesAsync();
         return true;
     }
+    
+    public async Task<bool> AuthorByNameExists(string authorName)
+    {
+        if (string.IsNullOrWhiteSpace(authorName))
+            return false;
+
+        return await _context.Authors
+            .AnyAsync(a => a.UserName == authorName);
+    }
 }

--- a/src/Chirp.Infrastructure/Chirp.Service/CheepService.cs
+++ b/src/Chirp.Infrastructure/Chirp.Service/CheepService.cs
@@ -164,5 +164,8 @@ public class CheepService : ICheepService
         return await _repository.DeleteAuthor(authorName);
     }
 
-
+    public Task<bool> AuthorByNameExists(string authorName)
+    {
+        return _repository.AuthorByNameExists(authorName);
+    }
 }

--- a/src/Chirp.Web/Pages/UserInformation.cshtml
+++ b/src/Chirp.Web/Pages/UserInformation.cshtml
@@ -18,7 +18,9 @@
         <h2> About me </h2>
         
         <p> This is your personal information page. This page provides an overview 
-            of all personal information that Chirp! stores about you. You can download a complete overview down below.</p>
+            of all personal information that Chirp! stores about you. You can download a complete overview down below.
+            If you wish to delete your account, click on 'Forget me!' down below.
+            </p>
         
         <h3 style="display: inline-block;"> Your username: </h3> 
         <p style="display: inline-block;">@(User.Identity.Name)</p>
@@ -44,18 +46,26 @@
                     <div class="pagination">
                         @if (Model.CurrentPage > 1)
                         {
-                            <a class="btn" href="/@(Model.CurrentAuthor)/aboutme/?page=@(Model.CurrentPage - 1)"> <button> Previous </button> </a>
+                            <a class="btn" href="/@(Model.CurrentAuthor)/aboutme/?page=@(Model.CurrentPage - 1)"> <button class="aboutmebtn"> Previous </button> </a>
                         }
 
                         @if (Model.HasNextPage)
                         {
-                            <a class="btn" href="/@(Model.CurrentAuthor)/aboutme/?page=@(Model.CurrentPage + 1)"> <button> Next </button> </a>
+                            <a class="btn" href="/@(Model.CurrentAuthor)/aboutme/?page=@(Model.CurrentPage + 1)"> <button class="aboutmebtn"> Next </button> </a>
                         }
                     </div>
                 }
                 else
                 {
-                    <p>You haven't posted any cheeps yet.</p>
+                    if (Model.CurrentPage > 1)
+                    {
+                        <p> No cheeps on this page. </p>
+                        <a class="btn" href="/@(Model.CurrentAuthor)/aboutme/?page=@(Model.CurrentPage - 1)"> <button class="aboutmebtn"> Previous </button> </a>
+                    }
+                    else
+                    {
+                        <p>You haven't posted any cheeps yet.</p>
+                    }
                 }
             </div>
         

--- a/src/Chirp.Web/Pages/UserTimeline.cshtml
+++ b/src/Chirp.Web/Pages/UserTimeline.cshtml
@@ -6,54 +6,63 @@
     Layout = "Shared/_Layout";
     var routeName = HttpContext.GetRouteValue("author");
 }
+@if(Model.AuthorExists){
+    <div>
+        <h2>@routeName's Timeline</h2>
+        @{ await Html.RenderPartialAsync("Shared/_PostPartial", Model.Input);}
 
-<div>
-    <h2>@routeName's Timeline</h2>
-    @{ await Html.RenderPartialAsync("Shared/_PostPartial", Model.Input);}
-
-    @if (Model.Cheeps.Any())
-    {
-        <ul id="messagelist" class="cheeps">
-            @foreach (var cheep in Model.Cheeps)
-            { 
-                <li>
-                    <div class="followcontainer">
-                        <strong>
-                            <a href="/@cheep.Author">@cheep.Author</a>
-                        </strong>
-                        @{ await Html.RenderPartialAsync("Shared/_FollowPartial",
-                               new FollowButtonViewModel(cheep.CheepId, cheep.Author, await Model.IsFollowing(cheep.Author))); }
-                    </div>
-                    @cheep.Message
-                    <small>&mdash; @cheep.TimeStamp</small>
-                </li>
-            }
-        </ul>
-        
-        @* Next/previous button for pagination *@
-        <div class="pagination">
-            @if (Model.CurrentPage > 1)
-            {
-                <a class="btn" href="/@(Model.CurrentAuthor)?page=@(Model.CurrentPage - 1)"> <button> Previous </button> </a>
-            }
-            
-            @if (Model.HasNextPage){
-                <a class="btn" href="/@(Model.CurrentAuthor)?page=@(Model.CurrentPage + 1)"> <button> Next </button> </a>
-            }
-        </div>
-    }
-    else
-    {
-        @if (Model.CurrentPage > 1)
+        @if (Model.Cheeps.Any())
         {
-            <em> No cheeps on current pagenumber: @(Model.CurrentPage) </em>
+            <ul id="messagelist" class="cheeps">
+                @foreach (var cheep in Model.Cheeps)
+                { 
+                    <li>
+                        <div class="followcontainer">
+                            <strong>
+                                <a href="/@cheep.Author">@cheep.Author</a>
+                            </strong>
+                            @{ await Html.RenderPartialAsync("Shared/_FollowPartial",
+                                   new FollowButtonViewModel(cheep.CheepId, cheep.Author, await Model.IsFollowing(cheep.Author))); }
+                        </div>
+                        @cheep.Message
+                        <small>&mdash; @cheep.TimeStamp</small>
+                    </li>
+                }
+            </ul>
+        
+            @* Next/previous button for pagination *@
+            <div class="pagination">
+                @if (Model.CurrentPage > 1)
+                {
+                    <a class="btn" href="/@(Model.CurrentAuthor)?page=@(Model.CurrentPage - 1)"> <button> Previous </button> </a>
+                }
             
-            <br> <br>
-            <a class="btn" href="/@(Model.CurrentAuthor)?page=@(Model.CurrentPage - 1)"> <button> Previous </button> </a>
+                @if (Model.HasNextPage){
+                    <a class="btn" href="/@(Model.CurrentAuthor)?page=@(Model.CurrentPage + 1)"> <button> Next </button> </a>
+                }
+            </div>
         }
         else
         {
-            <em> There are no cheeps so far.</em>
+            @if (Model.CurrentPage > 1)
+            {
+                <em> No cheeps on current pagenumber: @(Model.CurrentPage) </em>
+            
+                <br> <br>
+                <a class="btn" href="/@(Model.CurrentAuthor)?page=@(Model.CurrentPage - 1)"> <button> Previous </button> </a>
+            }
+            else
+            {
+                <em> There are no cheeps so far.</em>
+            }
         }
-    }
-</div>
+    </div>
+}
+else
+{
+    
+    <div>
+        <h2>User '@routeName' does not exist</h2>
+        <em> The user you are trying to view cannot be found.</em>
+    </div>
+}

--- a/src/Chirp.Web/Pages/UserTimeline.cshtml.cs
+++ b/src/Chirp.Web/Pages/UserTimeline.cshtml.cs
@@ -16,7 +16,8 @@ public class UserTimelineModel : PageModel
     public bool HasNextPage { get; set; }
     public readonly int pageSize = 32; 
     public int CurrentPage; 
-    public string CurrentAuthor = string.Empty; 
+    public string CurrentAuthor = string.Empty;
+    public bool AuthorExists; 
 
     [BindProperty]
     public InputModel Input { get; set; } = new();
@@ -28,6 +29,9 @@ public class UserTimelineModel : PageModel
     
     public async Task<IActionResult> OnGetAsync(string author)
     {
+        AuthorExists  = await _service.AuthorByNameExists(author);
+        if(!AuthorExists)  return Page();
+        
         var pageQuery = Request.Query["page"];
         int pageno;
         

--- a/src/Chirp.Web/wwwroot/css/style.css
+++ b/src/Chirp.Web/wwwroot/css/style.css
@@ -138,6 +138,22 @@ div.page div.navigation form {
     margin-top: 20px;
 }
 
+.aboutmebtn {
+    border-radius: 12px;
+    padding: 6px 16px;
+    font-size: 14px;
+    font-weight: bold;
+    background: #F0FAF9;
+    border: 1px solid #DBF3F1;
+    color: #666;
+}
+
+.aboutmebtn:hover {
+    background: #D9EFED;
+    border-color: #B9E0DC;
+    color: #333;
+}
+
 .followcontainer{
     display: flex;
     align-items: center;

--- a/test/Chirp.Razor.Tests/IntegrationTest.cs
+++ b/test/Chirp.Razor.Tests/IntegrationTest.cs
@@ -41,15 +41,15 @@ public class IntegrationTest : IClassFixture<WebApplicationFactory<Program>>
     [Theory]
     [InlineData("NonExistentUser123")]
     [InlineData("Invalid!User")]
-    public async Task CanSeePrivateTimeline_InvalidAuthor(string author)
+    public async Task CanSeeNotPrivateTimeline_InvalidAuthor(string author)
     {
         var response = await _client.GetAsync($"/{author}");
         response.EnsureSuccessStatusCode();
         var content = await response.Content.ReadAsStringAsync();
 
         content.Should().Contain("Chirp!");
-        content.Should().Contain($"{author}'s Timeline");
-        content.Should().Contain("There are no cheeps so far.");
+        content.Should().Contain($"User '{author}' does not exist");
+        content.Should().Contain("The user you are trying to view cannot be found.");
     }
 
     [Theory]
@@ -86,15 +86,16 @@ public class IntegrationTest : IClassFixture<WebApplicationFactory<Program>>
     [InlineData("NonexistentUser123", "?page=-1")]
     [InlineData("NonexistentUser123", "?page=abc")]
     [InlineData("Invalid!User", "?page=0")]
-    public async Task InvalidAuthorAndPageQuery_ShouldReturnEmptyTimeline(string author, string query)
+    public async Task InvalidAuthorAndPageQuery_ShouldReturnNotExistTimeline(string author, string query)
     {
         var response = await _client.GetAsync($"/{author}/{query}");
         response.EnsureSuccessStatusCode();
 
         var content = await response.Content.ReadAsStringAsync();
 
-        content.Should().Contain($"{author}'s Timeline");
-        content.Should().Contain("There are no cheeps so far.");
+        content.Should().Contain("Chirp!");
+        content.Should().Contain($"User '{author}' does not exist");
+        content.Should().Contain("The user you are trying to view cannot be found.");
     }
 
     [Fact]


### PR DESCRIPTION
Add method in repo and service to check if a user exists by name. Prevent rendering of private timeline for nonexistent users; show "User does not exist" instead. Update integration test to validate that private timeline is not shown for nonexistent users. Extra: Add styling to about-me page. Close #98.